### PR TITLE
Memory limit avoid oom

### DIFF
--- a/VXUGCollector.py
+++ b/VXUGCollector.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 import os
 
 from typing import List
@@ -11,6 +12,8 @@ from malwaretl_stoq_transformer import transformer
 
 from malware_collector import MalwareCollector
 
+
+logger = logging.getLogger("vxug collector")
 
 class VXUGCollector(MalwareCollector):
     # collect malware from https://samples.vx-underground.org/samples/Blocks/
@@ -36,7 +39,7 @@ class VXUGCollector(MalwareCollector):
             os.mkdir(target_dir)
         full_saved_path = os.path.join(target_dir, name)
         if not os.path.exists(full_saved_path):
-            print(f"downloading {name}")
+            logger.info(f"downloading {name}")
             response = requests.get(download_url, stream=True, timeout=60)
             with open(full_saved_path, "wb") as fileHandle:
                 for chunk in response.iter_content(chunk_size=8192):
@@ -68,13 +71,15 @@ class VXUGCollector(MalwareCollector):
 
 
 if __name__ == "__main__":
-    print("starting run")
-    stoq = transformer.init_vxug(scan_mode=True)
-    vx = VXUGCollector()
-    downloaded_files = vx.run()
-    print(f"finished download, grabbed {len(downloaded_files)} files")
+    logger.info("starting run")
+    input_mode = transformer.InputMode.manual
+    output_mode = transformer.OutputMode.silent
+    stoq, metadata = transformer.init_vxug(input_mode=input_mode, output_mode=output_mode)
+    stoq.log.disabled = True
+    vxug = VXUGCollector()
+    downloaded_files = vxug.run()
+    logger.info(f"finished download, grabbed {len(downloaded_files)} files")
     if downloaded_files:
-        stoq, metadata = transformer.init_vxug(scan_mode=True)
         metadata.extra_data['collection_time'] = datetime.datetime.utcnow().isoformat()
-        vx.scan_downloaded_files(stoq, metadata, downloaded_files)
-    print("done")
+        vxug.scan_downloaded_files(stoq, metadata, downloaded_files)
+    logger.info("done")

--- a/VXUGCollector.py
+++ b/VXUGCollector.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 import os
 
-from typing import List
+from typing import List, Optional
 from urllib.parse import urlparse
 
 import requests
@@ -29,7 +29,7 @@ class VXUGCollector(MalwareCollector):
         super().__init__()
         self.path = os.environ.get("VXUG_PATH", "/RAID")
 
-    def download_file(self, href, name, subdir) -> str:
+    def download_file(self, href, name, subdir) -> Optional[str]:
         if href.startswith("http"):
             download_url = href
         else:
@@ -44,7 +44,8 @@ class VXUGCollector(MalwareCollector):
             with open(full_saved_path, "wb") as fileHandle:
                 for chunk in response.iter_content(chunk_size=8192):
                     fileHandle.write(chunk)
-        return full_saved_path
+            return full_saved_path
+        return None
 
     @staticmethod
     def should_download_link(href) -> bool:
@@ -66,7 +67,8 @@ class VXUGCollector(MalwareCollector):
                     name = a.text
                     if self.should_download_link(href):
                         final_path = self.download_file(href, name, sub_dir)
-                        downloaded_files.append(final_path)
+                        if final_path is not None:
+                            downloaded_files.append(final_path)
         return downloaded_files
 
 

--- a/kubernetes/vxug-collector-pod.yaml
+++ b/kubernetes/vxug-collector-pod.yaml
@@ -16,7 +16,7 @@ spec:
                 claimName: vxug-pvc
           containers:
             - name: vxug-collector
-              image: gclef/vxug:1.20
+              image: gclef/vxug:1.21
               imagePullPolicy: "IfNotPresent"
               resources:
                 limits:

--- a/kubernetes/vxug-collector-pod.yaml
+++ b/kubernetes/vxug-collector-pod.yaml
@@ -20,9 +20,9 @@ spec:
               imagePullPolicy: "IfNotPresent"
               resources:
                 limits:
-                  memory: "6Gi"
+                  memory: "2Gi"
                 requests:
-                  memory: "4Gi"
+                  memory: "2Gi"
               volumeMounts:
                 - name: malware-mount
                   mountPath: /RAID

--- a/kubernetes/vxug-collector-pod.yaml
+++ b/kubernetes/vxug-collector-pod.yaml
@@ -16,7 +16,7 @@ spec:
                 claimName: vxug-pvc
           containers:
             - name: vxug-collector
-              image: gclef/vxug:1.21
+              image: gclef/vxug:1.22
               imagePullPolicy: "IfNotPresent"
               resources:
                 limits:

--- a/kubernetes/vxug-collector-pod.yaml
+++ b/kubernetes/vxug-collector-pod.yaml
@@ -16,7 +16,7 @@ spec:
                 claimName: vxug-pvc
           containers:
             - name: vxug-collector
-              image: gclef/vxug:1.22
+              image: gclef/vxug:1.24
               imagePullPolicy: "IfNotPresent"
               resources:
                 limits:

--- a/malware_collector.py
+++ b/malware_collector.py
@@ -1,12 +1,15 @@
 import asyncio
 import configparser
 import datetime
+import logging
 
 import os
 import git
 
 from typing import List, Optional, Tuple
 
+
+log = logging.getLogger("malware_collector")
 
 class MalwareCollector:
     def __init__(self):
@@ -71,6 +74,7 @@ class MalwareCollector:
         return daydirname
 
     def scan_single_file(self, stoq, metadata, target):
+        log.info(f"scanning {target}")
         filehandle = open(target, "rb")
         if "file_path" not in metadata.extra_data or metadata.extra_data['file_path'] != target:
             metadata.extra_data['file_path'] = target

--- a/malware_collector.py
+++ b/malware_collector.py
@@ -80,11 +80,15 @@ class MalwareCollector:
         file_size = os.path.getsize(target)
         if file_size > self.max_file_size:
             log.error(f"File {target} too big to load for scanning: {file_size}")
+            return
         filehandle = open(target, "rb")
         if "file_path" not in metadata.extra_data or metadata.extra_data['file_path'] != target:
             metadata.extra_data['file_path'] = target
-
-        self.loop.run_until_complete(stoq.scan(content=filehandle.read(), request_meta=metadata))
+        try:
+            data = filehandle.read()
+            self.loop.run_until_complete(stoq.scan(content=data, request_meta=metadata))
+        except OSError:
+            log.exception(f"error reading data from {target}")
 
     def scan_downloaded_files(self, stoq, metadata, files_downloaded):
         for file_path in files_downloaded:

--- a/malware_collector.py
+++ b/malware_collector.py
@@ -12,11 +12,13 @@ from typing import List, Optional, Tuple
 log = logging.getLogger("malware_collector")
 
 class MalwareCollector:
-    def __init__(self):
+    def __init__(self, max_file_size=50_000_000):
         self.configfile = configparser.ConfigParser()
         self.configfile.read("malware_collector.conf")
         self.archive_prefix = os.environ.get("ARCHIVE_PATH", "/RAID")
         self._cleanup = os.environ.get("CLEANUP", "false").lower() in ("true", "True", 1)
+        # don't open any file bigger than 50MB
+        self.max_file_size = max_file_size
         self.path = None
         self.loop = asyncio.get_event_loop()
         self.repo: Optional[git.Repo] = None
@@ -75,9 +77,13 @@ class MalwareCollector:
 
     def scan_single_file(self, stoq, metadata, target):
         log.info(f"scanning {target}")
+        file_size = os.path.getsize(target)
+        if file_size > self.max_file_size:
+            log.error(f"File {target} too big to load for scanning: {file_size}")
         filehandle = open(target, "rb")
         if "file_path" not in metadata.extra_data or metadata.extra_data['file_path'] != target:
             metadata.extra_data['file_path'] = target
+
         self.loop.run_until_complete(stoq.scan(content=filehandle.read(), request_meta=metadata))
 
     def scan_downloaded_files(self, stoq, metadata, files_downloaded):


### PR DESCRIPTION
Jobs were periodicallly OOM'ing and getting killed by the node during the stoq section of this download. Set lower Memory requests and limit to fix.